### PR TITLE
Fix `--exclude` option to allow multiple values

### DIFF
--- a/src/Commands/AnalyzeDependencyCommand.php
+++ b/src/Commands/AnalyzeDependencyCommand.php
@@ -33,7 +33,7 @@ abstract class AnalyzeDependencyCommand extends Command
             ->setDefinition([
                 new InputArgument('paths', InputArgument::REQUIRED | InputArgument::IS_ARRAY, 'Target directory of analyze'),
                 new InputOption('memory-limit', null, InputOption::VALUE_REQUIRED, 'Memory limit for the run (ex: 500k, 500M, 5G)'),
-                new InputOption('exclude', null, InputOption::VALUE_REQUIRED | InputArgument::IS_ARRAY, 'Exclude directory of analyze'),
+                new InputOption('exclude', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Exclude directory of analyze'),
             ]);
     }
 
@@ -46,7 +46,7 @@ abstract class AnalyzeDependencyCommand extends Command
         $dependencyGraph = $this->createDependencyGraph(
             $output,
             $input->getArgument('paths'),
-            !is_null($input->getOption('exclude')) ? [$input->getOption('exclude')] : []
+            !is_null($input->getOption('exclude')) ? $input->getOption('exclude') : []
         );
 
         return $this->inspectDependencyGraph($dependencyGraph, $output);


### PR DESCRIPTION
This PR fixes problem I mentioned in #3 .

I replaced `InputArgument::IS_ARRAY` to `InputOption::VALUE_IS_ARRAY`.

see: https://symfony.com/doc/current/console/input.html#using-command-options