### PR TITLE
fix tests

### DIFF
--- a/src/DependencyDumper/DependencyResolver.php
+++ b/src/DependencyDumper/DependencyResolver.php
@@ -400,17 +400,15 @@ class DependencyResolver
 
     protected function resolveMethodCall(\PhpParser\Node\Expr\MethodCall $node, Scope $scope)
     {
-        if ($node instanceof Identifier) {
-            $classNames = $scope->getType($node->var)->getReferencedClasses();
-            foreach ($classNames as $className) {
-                if ($dependee = $this->resolveClassReflectionOrAddUnkownDependency($className)) {
-                    $this->dependencyGraphBuilder->addMethodCall(
-                        $this->depender,
-                        $dependee->getNativeReflection(),
-                        $node->name->toString(),
-                        $scope->getFunctionName()
-                    );
-                }
+        $classNames = $scope->getType($node->var)->getReferencedClasses();
+        foreach ($classNames as $className) {
+            if ($dependee = $this->resolveClassReflectionOrAddUnkownDependency($className)) {
+                $this->dependencyGraphBuilder->addMethodCall(
+                    $this->depender,
+                    $dependee->getNativeReflection(),
+                    $node->name->toString(),
+                    $scope->getFunctionName()
+                );
             }
         }
 


### PR DESCRIPTION
\PhpParser\Node\Expr\MethodCall is not a Derivative of Identifier.